### PR TITLE
docker: Pin ubuntu version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:16.04
 MAINTAINER Sawood Alam <ibnesayeed@gmail.com>
 
 RUN apt-get update && apt-get -y install git make perl cpanminus python curl libcurl3 libcurl3-dev supervisor build-essential


### PR DESCRIPTION
Current LTS 18.04 did not work, so I tried older one

Signed-off-by: Philippe Coval <rzr@users.sf.net>